### PR TITLE
added warning about parking at the Sand campus

### DIFF
--- a/src/tuebingen.tex
+++ b/src/tuebingen.tex
@@ -2,7 +2,7 @@
     \fett{Public transport in Tübingen}
     Bus schedules can be found online\footnote{\url{https://naldo.de}} and in the Naldo app for Android and iOS.\\
     The best way to get to the "`Morgenstelle"' (see city map on the last page) is to take the bus (destination stop BG-Unfallklinik\footnote{\textbf{not} "`Auf der Morgenstelle"'!}). There is a very limited number of parking lots at the Morgenstelle, but one has to apply for permission to use them, first.
-    Most Master events/lectures take place on the "`Sand"', the place of the WSI (Wilhelm-Schickard-Institut). To get to the Sand, take line 2, stop \emph{Sand Drosselweg}. It is also easily reached by car as there are multiple parking lots.
+    Most Master events/lectures take place on the "`Sand"', the place of the WSI (Wilhelm-Schickard-Institut). To get to the Sand, take line 2, stop \emph{Sand Drosselweg}. It is also reachable by car. In the past there were multiple parking lots, but these are currently being taken away and are supposed to have fees for parking soon. It is best to assume that there will be only few places available and that they will cost something until further notice.
     Some Machine Learning lectures take place in the Maria-von-Linden-Straße 6. To get there, take line 3, stop \emph{Maria-von-Linden-Straße}.
     With your semester fee, you have already paid part of the semester ticket for the bus (in addition to the student union fee and the matriculation fee).
     
@@ -44,7 +44,7 @@
     Die Bushaltestelle für die Unigebäude an der \emph{Morgenstelle} (siehe Stadtplan auf der letzten Seite) heißt "`BG-Unfallklinik"'\footnote{\textbf{nicht} "`Auf der Morgenstelle"'!}). Es gibt zwar auch Parkplätze dort,
     jedoch muss man deren Benutzung beantragen und die Anzahl an Parkplätzen ist ohnehin sehr begrenzt.
     \ifmaster
-    Die meisten Master-Veranstaltungen finden auf dem \emph{Sand}, dem Sitz des WSI (Wilhelm-Schickard-Institut), statt. Die Bushaltestelle heißt "`Sand Drosselweg"'.
+    Die meisten Master-Veranstaltungen finden auf dem \emph{Sand}, dem Sitz des WSI (Wilhelm-Schickard-Institut), statt. Die Bushaltestelle heißt "`Sand Drosselweg"'. Der Sand ist auch mit dem Auto erreichbar, allerdings hat das Land momentan vor, die Kontrolle über die Parkplätze aufzunehmen. Deswegen ist es besser, bis auf Weiteres anzunehmen, dass es da nur wenige und kostenpflichtige Parkmöglichkeiten gibt.
     \fi
     
     Das Semesterticket kostet \semesterticketpreis~EUR und gilt im ganzen Naldogebiet, dem Verkehrsverbund rund um Tübingen (leider nicht bis Stuttgart, dafür bis Überlingen am Bodensee).

--- a/src/tuebingen.tex
+++ b/src/tuebingen.tex
@@ -2,7 +2,7 @@
     \fett{Public transport in Tübingen}
     Bus schedules can be found online\footnote{\url{https://naldo.de}} and in the Naldo app for Android and iOS.\\
     The best way to get to the "`Morgenstelle"' (see city map on the last page) is to take the bus (destination stop BG-Unfallklinik\footnote{\textbf{not} "`Auf der Morgenstelle"'!}). There is a very limited number of parking lots at the Morgenstelle, but one has to apply for permission to use them, first.
-    Most Master events/lectures take place on the "`Sand"', the place of the WSI (Wilhelm-Schickard-Institut). To get to the Sand, take line 2, stop \emph{Sand Drosselweg}. It is also reachable by car. In the past there were multiple parking lots, but these are currently being taken away and are supposed to have fees for parking soon. It is best to assume that there will be only few places available and that they will cost something until further notice.
+    Most Master events/lectures take place on the "`Sand"', the place of the WSI (Wilhelm-Schickard-Institut). To get to the Sand, take line 2, stop \emph{Sand Drosselweg}.  It is also reachable by car. However, please note that starting in October, parking will no longer be free. Unfortunately, further details, such as the exact parking rates, are not yet available.
     Some Machine Learning lectures take place in the Maria-von-Linden-Straße 6. To get there, take line 3, stop \emph{Maria-von-Linden-Straße}.
     With your semester fee, you have already paid part of the semester ticket for the bus (in addition to the student union fee and the matriculation fee).
     
@@ -44,8 +44,7 @@
     Die Bushaltestelle für die Unigebäude an der \emph{Morgenstelle} (siehe Stadtplan auf der letzten Seite) heißt "`BG-Unfallklinik"'\footnote{\textbf{nicht} "`Auf der Morgenstelle"'!}). Es gibt zwar auch Parkplätze dort,
     jedoch muss man deren Benutzung beantragen und die Anzahl an Parkplätzen ist ohnehin sehr begrenzt.
     \ifmaster
-    Die meisten Master-Veranstaltungen finden auf dem \emph{Sand}, dem Sitz des WSI (Wilhelm-Schickard-Institut), statt. Die Bushaltestelle heißt "`Sand Drosselweg"'. Der Sand ist auch mit dem Auto erreichbar, allerdings hat das Land momentan vor, die Kontrolle über die Parkplätze aufzunehmen. Deswegen ist es besser, bis auf Weiteres anzunehmen, dass es da nur wenige und kostenpflichtige Parkmöglichkeiten gibt.
-    \fi
+    Die meisten Master-Veranstaltungen finden auf dem Sand statt (Wilhelm-Schickard-Institut). Der Sand lässt sich mit der Buslinie 2 erreichen. Die nächstgelegene Bushaltestelle heißt "`Sand Drosselweg"'. Der Sand ist ebenfalls mit dem Auto erreichbar, allerdings werden die Parkplätze dort ab Oktober kostenpflichtig. Genauere Informationen, z.B. zu den Gebühren, haben wir aktuell leider noch nicht.    \fi
     
     Das Semesterticket kostet \semesterticketpreis~EUR und gilt im ganzen Naldogebiet, dem Verkehrsverbund rund um Tübingen (leider nicht bis Stuttgart, dafür bis Überlingen am Bodensee).
     


### PR DESCRIPTION
a short sentence in the English and German text of the "verkehr in tübingen" section of "tuebingen.tex" was added, which warns about parking on the Sand campus, with the recommendation to expect few parking spaces with fees