### PR TITLE
updated ticket options and prices for winter term 2025

### DIFF
--- a/src/config.tex
+++ b/src/config.tex
@@ -10,11 +10,11 @@
 
 % 2. Ticketpreise anpassen
 % Link WS23 https://www.naldo.de/tickets/semesterticket/
-\newcommand{\semesterticketpreis}{TODO}
+\newcommand{\semesterticketpreis}{153,10}
 % https://www.naldo.de/tickets/dticket-jugendbw-studierende/
-\newcommand{\jugendticketbwpreis}{TODO}
+\newcommand{\jugendticketbwpreis}{39,42}
 % https://www.swtue.de/oepnv/tickets/deutschlandticket-fuer-uebersicht.html
-\newcommand{\detickettuepreis}{TODO}
+\newcommand{\detickettuepreis}{58}
 
 % Link WS24 https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studienbeginn/mathematischer-vorbereitungskurs/
 % 3. Mathe Vorkurs

--- a/src/config.tex
+++ b/src/config.tex
@@ -15,6 +15,9 @@
 \newcommand{\jugendticketbwpreis}{39,42}
 % https://www.swtue.de/oepnv/tickets/deutschlandticket-fuer-uebersicht.html
 \newcommand{\detickettuepreis}{58}
+% discounted ticket for residents of Tübingen and its districts
+% https://www.naldo.de/tickets/deutschlandticket-tuebingen/
+\newcommand{\detickettuebewohnipreis}{49}
 
 % Link WS24 https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studienbeginn/mathematischer-vorbereitungskurs/
 % 3. Mathe Vorkurs

--- a/src/tuebingen.tex
+++ b/src/tuebingen.tex
@@ -21,6 +21,7 @@
 
     As an alternative for older students, there is also the normal Deutschlandticket, which is valid for one month and is available for \detickettuepreis~EUR. 
     It should be noted that the paper ticket must be ordered by the 15th of the previous month at the latest, and the mobile ticket at least two days before the start of the month.
+    For residents of Tübingen and surrounding areas, the Deutschlandticket costs only \detickettuebewohnipreis euros.
 
     All three tickets are available in the DB travel centres and online\footnote{\url{https://tickets.naldo.de}}. For the online purchase, you need a login ID of the university (starting with \texttt{zx}).
     In order to buy one of these tickets offline, you will need to show your student ID and the Semester Ticket Certificate\footnote{alma > My Studies > Student Service > Requested Reports/Reports > Naldo-Bescheinigung}. For the D-Ticket JugendBW (Studierende), you must also show an official photo ID as proof of age.\\
@@ -61,6 +62,7 @@
 
     Alternativ gibt es für ältere Studierende noch das Deutschlandticket, das jeweils für einen Monat gültig ist und für \detickettuepreis~EUR erhältlich ist. 
     Es ist zu beachten, dass hier das Papierticket bereits bis spätestens zum 15. des Vormonats, das Handyticket bis zwei Tage vor Monatsbeginn bestellt werden muss.
+    Für Einwohner:innen in Tübingen und Teilorte kostet das Deutschlandticket nur \detickettuebewohnipreis Euro.
 
     Alle drei Tickets sind in den Reisezentren der DB und online\footnote{\url{https://tickets.naldo.de}} erhältlich. Für den Online-Kauf benötigt ihr eine Login-ID der Uni (beginnend mit \texttt{zx}). Falls ihr eines dieser Tickets offline kaufen möchtet, müsst ihr euren Studiausweis
     sowie die "`Naldo-Bescheinigung"'\footnote{alma > Mein Studium > Studienservice > Bescheide/Bescheinigungen} vorzeigen. Für das D-Ticket JugendBW (Studierende) müsst ihr als Altersnachweis zusätzlich einen amtlichen Lichtbildausweis zeigen. 

--- a/src/tuebingen.tex
+++ b/src/tuebingen.tex
@@ -9,8 +9,8 @@
     The semester ticket costs \semesterticketpreis~EUR and is valid in the whole Naldo area, a public transport system around
     Tübingen (unfortunately not to Stuttgart, but to Überlingen at Lake Constance).
     
-    The Deutschlandticket JugendBW (Studierende) costs \jugendticketbwpreis~EUR and is valid in the whole of Germany (not for long-distance lines, i.e. ICE, IC, EC and long-distance coach).
-    In contrast to the Semesterticket, the D-Ticekt JugendBW has an age restriction, it can only be purchased by students who are under the age of 27 at the beginning of the semester.
+    The Deutschlandticket JugendBW (Studierende) costs \jugendticketbwpreis~EUR per month and is valid in the whole of Germany (not for long-distance lines, i.e. ICE, IC, EC and long-distance coach).
+    In contrast to the Semesterticket, the D-Ticekt JugendBW has an age restriction, it can only be purchased by students who are under the age of 27 at the beginning of the semester. Please note that the ticket has a minimum subscription period of 12 months.
     Both tickets are valid from
     \ifwintersemester
     October 1st.
@@ -49,9 +49,9 @@
     
     Das Semesterticket kostet \semesterticketpreis~EUR und gilt im ganzen Naldogebiet, dem Verkehrsverbund rund um Tübingen (leider nicht bis Stuttgart, dafür bis Überlingen am Bodensee).
     
-    Das Deutschlandticket JugendBW (Studierende) kostet \jugendticketbwpreis~EUR und gilt im ÖPNV in ganz Deutschland (nicht im Fernverkehr, also ICE, IC, EC und Fernbus). Im Gegensatz zum Semesterticket gibt es beim D-Ticket JugendBW (Studierende) eine Altersbeschränkung,
-    es kann nur von Studierenden gekauft werden, die zu Beginn des Semesters unter 27 Jahre alt sind.
-    Beide Tickets gelten jeweils ab dem
+    Das Deutschlandticket JugendBW (Studierende) kostet \jugendticketbwpreis~EUR pro Monat und gilt im ÖPNV in ganz Deutschland (nicht im Fernverkehr, also ICE, IC, EC und Fernbus). Im Gegensatz zum Semesterticket gibt es beim D-Ticket JugendBW (Studierende) eine Altersbeschränkung,
+    es kann nur von Studierenden gekauft werden, die zu Beginn des Semesters unter 27 Jahre alt sind. Es ist zu beachten, dass das Ticket ein Mindestbezug von 12 Monaten hat.
+
     \ifwintersemester
     1. Oktober.
     \fi


### PR DESCRIPTION
Updated ticket prices in `config.tex`according to these websites: 

https://www.naldo.de/fileadmin/media/verbund/presse/naldo-Tarifvergleich-Okt-2024-Okt-2025.pdf
https://www.naldo.de/tickets/dticket-jugendbw-studierende/

Introduced `\detickettuebewohnispreis` in file `config.tex` for reduced deticket price for residents of tübingen and surrounding areas. 

Also added a sentence in `tuebingen.tex`.

I added in `tuebingen.tex` that JugendBW-ticket now is paid monthly with minimum  minimum subscription period of 12 months. 

Pleade double check this, I'm not quite sure if I understood that right. 