### PR TITLE
Fix/language

### DIFF
--- a/media/anfibrief.lco
+++ b/media/anfibrief.lco
@@ -4,12 +4,12 @@
 \usepackage{xcolor}
 \definecolor{navy}{RGB}{0, 0, 128}
 
-\usepackage{ngerman}
+\usepackage[ngerman]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage[scaled]{berasans}
 \usepackage[T1]{fontenc}
 \usepackage{graphicx}
-\usepackage{fontawesome} % Icons in Adresskopf
+\usepackage{fontawesome5} % Icons in Adresskopf
 \renewcommand{\familydefault}{\sfdefault}
 
 \usepackage{geometry}

--- a/media/anfibrief.lco
+++ b/media/anfibrief.lco
@@ -113,7 +113,6 @@
 	\seticon{faAt} \quad kogni-fachschaft@fsi.uni-tuebingen.de \\
 	\seticon{faAt} \quad kogni-beratung@fsi.uni-tuebingen.de \\
 	\seticon{faGlobe} \quad www.fs-kogni.uni-tuebingen.de\\
-	\section{faInstagram} \quad @fsk.tuebingen\\
 	\\ 
 	\seticon{faMapMarker} \quad Sand 14, Raum C102 \\ 
 	\hspace*{1em}\quad 72076 Tübingen
@@ -168,8 +167,6 @@
 	  \seticon{faPhone} \quad +49 7071 29-70413 \\
 	  \seticon{faAt} \quad fsi@fsi.uni-tuebingen.de \\
 	  \seticon{faGlobe} \quad  www.fsi.uni-tuebingen.de\\
-	  \section{faInstagram} \quad @fsi_tuebingen\\
-	  \section{faMastodon} \quad @fsi_tue\\
 	  \\ 
 	  \seticon{faMapMarker} \quad Sand 14, Raum C125 \\ 
 	  \hspace*{1em}\quad 72076 Tübingen

--- a/media/anfibrief.lco
+++ b/media/anfibrief.lco
@@ -113,6 +113,7 @@
 	\seticon{faAt} \quad kogni-fachschaft@fsi.uni-tuebingen.de \\
 	\seticon{faAt} \quad kogni-beratung@fsi.uni-tuebingen.de \\
 	\seticon{faGlobe} \quad www.fs-kogni.uni-tuebingen.de\\
+	\section{faInstagram} \quad @fsk.tuebingen\\
 	\\ 
 	\seticon{faMapMarker} \quad Sand 14, Raum C102 \\ 
 	\hspace*{1em}\quad 72076 Tübingen
@@ -167,6 +168,8 @@
 	  \seticon{faPhone} \quad +49 7071 29-70413 \\
 	  \seticon{faAt} \quad fsi@fsi.uni-tuebingen.de \\
 	  \seticon{faGlobe} \quad  www.fsi.uni-tuebingen.de\\
+	  \section{faInstagram} \quad @fsi_tuebingen\\
+	  \section{faMastodon} \quad @fsi_tue\\
 	  \\ 
 	  \seticon{faMapMarker} \quad Sand 14, Raum C125 \\ 
 	  \hspace*{1em}\quad 72076 Tübingen

--- a/src/brief_main.tex
+++ b/src/brief_main.tex
@@ -4,7 +4,7 @@
 % Packages
 \usepackage[utf8]{inputenc}
 \usepackage[htt]{hyphenat}
-\usepackage{german}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{pdfpages}
 \usepackage{xcolor}

--- a/src/brief_main_en.tex
+++ b/src/brief_main_en.tex
@@ -4,7 +4,7 @@
 % Packages
 \usepackage[utf8]{inputenc}
 \usepackage[htt]{hyphenat}
-\usepackage{german}
+\usepackage[ngerman]{babel}
 \usepackage{graphicx}
 \usepackage{pdfpages}
 \usepackage{eurosym}


### PR DESCRIPTION
`\usepackage{ngerman}` is outdated, so I replaced it with `\usepackage[ngerman]{babel}`.

Also updated `\usepackage{fontawesome}` to  `fontawesome5`, so we can add icons for instagram and mastodon.